### PR TITLE
update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ output being generated.
 
 To install the library and command line program, use the following:
 
-	go get -u github.com/jteeuwen/go-bindata/...
+	go get -u github.com/TykTechnologies/go-bindata/...
 
 
 ### Usage


### PR DESCRIPTION
update install instructions: 
they should point to the proper repo `github.com/TykTechnologies/go-bindata`